### PR TITLE
Upgrade action to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,5 +43,5 @@ inputs:
   signature-regex:
     description: "The regex to locate the signature text. Should be single quoted. Note that comment bodies are toUpperCase'd before matching."
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/index.js"


### PR DESCRIPTION
This is to fix the following warning: 
> The following actions uses node12 which is deprecated and will be forced to run on node16: MetaMask/cla-signature-bot@v3.0.2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/