### PR TITLE
chore: update action runtime to Node 24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,16 +15,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [24.x]
-
     steps:
     - uses: actions/checkout@v7
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 24
       uses: actions/setup-node@v7
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 24
     - name: Npm install
       run: npm ci
     - name: Npm build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,12 +17,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
     - name: Npm install

--- a/action.yml
+++ b/action.yml
@@ -43,5 +43,5 @@ inputs:
   signature-regex:
     description: "The regex to locate the signature text. Should be single quoted. Note that comment bodies are toUpperCase'd before matching."
 runs:
-  using: "node20"
+  using: "node24"
   main: "lib/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.8",
-        "@types/node": "^20.12.7",
+        "@types/node": "^24.13.3",
         "@types/node-fetch": "^2.6.9",
         "@vercel/ncc": "^0.38.1",
         "jest": "^29.7.0",
@@ -4094,11 +4094,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -10962,9 +10963,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.8",
-    "@types/node": "^20.12.7",
+    "@types/node": "^24.13.3",
     "@types/node-fetch": "^2.6.9",
     "@vercel/ncc": "^0.38.1",
     "jest": "^29.7.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Explanation

GitHub is deprecating Node 20 on Actions runners and forcing JavaScript actions onto Node 24. Consuming workflows (for example MetaMask Mobile CLABot using `MetaMask/cla-signature-bot@v3.0.2`) currently warn:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: MetaMask/cla-signature-bot@v3.0.2

This updates the action metadata to declare `node24`, matching [GitHub's JavaScript action runtime](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions) and [the Node 20 deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

This follows the same approach as the previous Node 12 → Node 20 bump (#6 / `v4.0.0`).

### Changes

- `action.yml`: `runs.using` `node20` → `node24`
- Build workflow: pin to Node 24 (no matrix; this action only supports one runtime)
- Build workflow: `actions/checkout@v7` and `actions/setup-node@v7` so CI itself is not on the deprecated Node 20 action runtime
- `@types/node` bumped to `^24.13.3` to match the runtime

### After merge

Cut a new release tag (likely `v5.0.0`, since `v4.0.0` is the Node 20 release). Consumer repos can then pin to that tag, for example:

```yml
uses: MetaMask/cla-signature-bot@v5.0.0
```

Until a new tag is published, existing pins such as `@v3.0.2` will keep targeting Node 20.

## Changelog

CHANGELOG.md is not present in this repository.

## Related

- Deprecation warning observed on MetaMask Mobile CLABot (`cla.yml`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edc682d5-e1d1-4fa1-8a96-0149011f3c43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edc682d5-e1d1-4fa1-8a96-0149011f3c43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

